### PR TITLE
FEAT manager features and community features

### DIFF
--- a/community/src/main/java/com/example/community_service/community/application/CommunityService.java
+++ b/community/src/main/java/com/example/community_service/community/application/CommunityService.java
@@ -6,10 +6,20 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 public interface CommunityService {
 
-    ResponseCreateCommunityDto createCommunity(RequestCreateCommunityDto requestCreateCommunityDto) throws JsonProcessingException;
-    ResponseUpdateCommunityDto updateCommunity(RequestUpdateCommunityDto requestUpdateCommunityDto, Long communityId);
-    ResponseBanUserDto banUser(RequestBanUserDto requestBanUserDto, Long communityId);
-    ResponseUnbanUserDto unbanUser(RequestUnbanUserDto requestUnbanUserDto, Long communityId);
+    // 커뮤니티 관리
+    ResponseCreateCommunityDto createCommunity(RequestCreateCommunityDto requestDto) throws JsonProcessingException;
+    ResponseUpdateCommunityDto updateCommunity(RequestUpdateCommunityDto requestDto, Long communityId);
+    ResponseGetCommunityMemberListDto getCommunityMemberList(RequestGetCommunityMemberListDto requestDto, Long communityId);
+
+    // 커뮤니티 밴유저 관리
+    ResponseBanUserDto banUser(RequestBanUserDto requestDto, Long communityId);
+    ResponseUnbanUserDto unbanUser(RequestUnbanUserDto requestDto, Long communityId);
     ResponseGetBannedUserListDto getBannedUserList(RequestGetBannedUserListDto requestDto, Long communityId);
+
+    // 커뮤니티 가입/탈퇴/조회
     ResponseJoinCommunityDto joinCommunity(RequestJoinCommunityDto requestDto, Long communityId);
+    ResponseLeaveCommunityDto leaveCommunity(RequestLeaveCommunityDto requestDto, Long communityId);
+
+    // 커뮤니티 매니저 관리
+    ResponseRegisterManagerDto registerManager(RequestRegisterManagerDto requestDto, Long communityId);
 }

--- a/community/src/main/java/com/example/community_service/community/domain/BannedUser.java
+++ b/community/src/main/java/com/example/community_service/community/domain/BannedUser.java
@@ -26,7 +26,6 @@ public class BannedUser {
     @Column(nullable = false, name = "banned_uuid")
     private String bannedUuid;
 
-    //todo: 밴 해제일 추가
     @Column(nullable = false, name = "ban_end_date")
     @DateTimeFormat(pattern = "yyyy-MM-dd hh:mm:ss")
     private LocalDateTime banEndDate;

--- a/community/src/main/java/com/example/community_service/community/dto/request/RequestGetCommunityMemberListDto.java
+++ b/community/src/main/java/com/example/community_service/community/dto/request/RequestGetCommunityMemberListDto.java
@@ -1,0 +1,15 @@
+package com.example.community_service.community.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestGetCommunityMemberListDto {
+
+    private String managerUuid;
+}

--- a/community/src/main/java/com/example/community_service/community/dto/request/RequestLeaveCommunityDto.java
+++ b/community/src/main/java/com/example/community_service/community/dto/request/RequestLeaveCommunityDto.java
@@ -1,0 +1,15 @@
+package com.example.community_service.community.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestLeaveCommunityDto {
+
+    private String userUuid;
+}

--- a/community/src/main/java/com/example/community_service/community/dto/request/RequestRegisterManagerDto.java
+++ b/community/src/main/java/com/example/community_service/community/dto/request/RequestRegisterManagerDto.java
@@ -1,0 +1,16 @@
+package com.example.community_service.community.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestRegisterManagerDto {
+
+    private String creatorUuid;
+    private String targetUuid;
+}

--- a/community/src/main/java/com/example/community_service/community/dto/response/ResponseGetCommunityMemberListDto.java
+++ b/community/src/main/java/com/example/community_service/community/dto/response/ResponseGetCommunityMemberListDto.java
@@ -1,0 +1,18 @@
+package com.example.community_service.community.dto.response;
+
+import com.example.community_service.community.domain.CommunityMember;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseGetCommunityMemberListDto {
+
+    private List<CommunityMember> communityMemberList;
+}

--- a/community/src/main/java/com/example/community_service/community/dto/response/ResponseLeaveCommunityDto.java
+++ b/community/src/main/java/com/example/community_service/community/dto/response/ResponseLeaveCommunityDto.java
@@ -1,0 +1,16 @@
+package com.example.community_service.community.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseLeaveCommunityDto {
+
+    private Long communityId;
+    private String userUuid;
+}

--- a/community/src/main/java/com/example/community_service/community/dto/response/ResponseRegisterManagerDto.java
+++ b/community/src/main/java/com/example/community_service/community/dto/response/ResponseRegisterManagerDto.java
@@ -1,0 +1,16 @@
+package com.example.community_service.community.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseRegisterManagerDto {
+
+    private Long communityId;
+    private String managerUuid;
+}

--- a/community/src/main/java/com/example/community_service/community/infrastructure/BannedUserRepository.java
+++ b/community/src/main/java/com/example/community_service/community/infrastructure/BannedUserRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 public interface BannedUserRepository extends JpaRepository<BannedUser, Long> {
 
+    Boolean existsByCommunityIdAndBannedUuid(Long communityId, String bannedUuid);
     Optional<BannedUser> findByCommunityIdAndBannedUuid(Long communityId, String bannedUuid);
     List<BannedUser> findAllByCommunityId(Long communityId);
 }

--- a/community/src/main/java/com/example/community_service/community/infrastructure/CommunityManagerRepository.java
+++ b/community/src/main/java/com/example/community_service/community/infrastructure/CommunityManagerRepository.java
@@ -3,7 +3,10 @@ package com.example.community_service.community.infrastructure;
 import com.example.community_service.community.domain.CommunityManager;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CommunityManagerRepository extends JpaRepository<CommunityManager, Long> {
 
     Boolean existsByCommunityIdAndManagerUuid(Long communityId, String managerUuid);
+    Optional<CommunityManager> findByCommunityIdAndManagerUuid(Long communityId, String managerUuid);
 }

--- a/community/src/main/java/com/example/community_service/community/infrastructure/CommunityMemberRepository.java
+++ b/community/src/main/java/com/example/community_service/community/infrastructure/CommunityMemberRepository.java
@@ -3,7 +3,12 @@ package com.example.community_service.community.infrastructure;
 import com.example.community_service.community.domain.CommunityMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface CommunityMemberRepository extends JpaRepository<CommunityMember, Long> {
 
+    Optional<CommunityMember> findByCommunityIdAndUserUuid(Long communityId, String userUuid);
+    List<CommunityMember> findAllByCommunityId(Long communityId);
     Boolean existsByCommunityIdAndUserUuid(Long communityId, String userUuid);
 }

--- a/community/src/main/java/com/example/community_service/community/presentation/CommunityController.java
+++ b/community/src/main/java/com/example/community_service/community/presentation/CommunityController.java
@@ -22,6 +22,7 @@ public class CommunityController {
 
     private final CommunityServiceImpl communityService;
 
+    // todo: 모든 엔티티에 createdAt, updatedAt 추가하기
     @Tag(name = "커뮤니티 가입/탈퇴/조회") @Operation(summary = "커뮤니티 가입")
     @PostMapping("/{communityId}/users/me")
     public ApiResponse<Object> joinCommunity(
@@ -34,6 +35,25 @@ public class CommunityController {
         ResponseJoinCommunityDto responseDto = communityService.joinCommunity(requestDto, communityId);
 
         ResponseJoinCommunityVo responseVo = ResponseJoinCommunityVo.builder()
+                .communityId(responseDto.getCommunityId())
+                .userUuid(responseDto.getUserUuid())
+                .build();
+
+        return ApiResponse.ofSuccess(responseVo);
+    }
+
+    @Tag(name = "커뮤니티 가입/탈퇴/조회") @Operation(summary = "커뮤니티 탈퇴")
+    @DeleteMapping("/{communityId}/users/me")
+    public ApiResponse<Object> leaveCommunity(
+            @Valid @RequestBody RequestLeaveCommunityVo requestVo, @PathVariable Long communityId) {
+
+        RequestLeaveCommunityDto requestDto = RequestLeaveCommunityDto.builder()
+                .userUuid(requestVo.getUserUuid())
+                .build();
+
+        ResponseLeaveCommunityDto responseDto = communityService.leaveCommunity(requestDto, communityId);
+
+        ResponseLeaveCommunityVo responseVo = ResponseLeaveCommunityVo.builder()
                 .communityId(responseDto.getCommunityId())
                 .userUuid(responseDto.getUserUuid())
                 .build();
@@ -81,6 +101,25 @@ public class CommunityController {
 
         ResponseUpdateCommunityVo responseVo = ResponseUpdateCommunityVo.builder()
                 .communityId(responseDto.getCommunityId())
+                .build();
+
+        return ApiResponse.ofSuccess(responseVo);
+    }
+
+    @Tag(name = "커뮤니티 관리") @Operation(summary = "커뮤니티 가입 회원 조회")
+    @PostMapping("/{communityId}/members/list")
+    public ApiResponse<Object> getCommunityMemberList(
+            @Valid @RequestBody RequestGetCommunityMemberListVo requestVo, @PathVariable Long communityId) {
+
+        RequestGetCommunityMemberListDto requestDto = RequestGetCommunityMemberListDto.builder()
+                .managerUuid(requestVo.getManagerUuid())
+                .build();
+
+        ResponseGetCommunityMemberListDto responseDto =
+                communityService.getCommunityMemberList(requestDto, communityId);
+
+        ResponseGetCommunityMemberListVo responseVo = ResponseGetCommunityMemberListVo.builder()
+                .communityMemberList(responseDto.getCommunityMemberList())
                 .build();
 
         return ApiResponse.ofSuccess(responseVo);
@@ -143,5 +182,37 @@ public class CommunityController {
                 .build();
 
         return ApiResponse.ofSuccess(responseVo);
+    }
+
+    @Tag(name = "커뮤니티 매니저 관리") @Operation(summary = "커뮤니티 매니저 등록")
+    @PostMapping("/{communityId}/managers")
+    public ApiResponse<Object> registerManager(
+            @Valid @RequestBody RequestRegisterManagerVo requestVo, @PathVariable Long communityId) {
+
+        RequestRegisterManagerDto requestDto = RequestRegisterManagerDto.builder()
+                .creatorUuid(requestVo.getCreatorUuid())
+                .targetUuid(requestVo.getTargetUuid())
+                .build();
+
+        ResponseRegisterManagerDto responseDto = communityService.registerManager(requestDto, communityId);
+
+        ResponseRegisterManagerVo responseVo = ResponseRegisterManagerVo.builder()
+                .managerUuid(responseDto.getManagerUuid())
+                .communityId(responseDto.getCommunityId())
+                .build();
+
+        return ApiResponse.ofSuccess(responseVo);
+    }
+
+    @Tag(name = "커뮤니티 매니저 관리") @Operation(summary = "커뮤니티 매니저 삭제")
+    @DeleteMapping("/{communityId}/managers")
+    public ApiResponse<Object> deleteManager() {
+        return ApiResponse.ofSuccess();
+    }
+
+    @Tag(name = "커뮤니티 매니저 관리") @Operation(summary = "커뮤니티 매니저 목록 조회")
+    @PostMapping("/{communityId}/managers/list")
+    public ApiResponse<Object> getManagerList() {
+        return ApiResponse.ofSuccess();
     }
 }

--- a/community/src/main/java/com/example/community_service/community/vo/request/RequestGetCommunityMemberListVo.java
+++ b/community/src/main/java/com/example/community_service/community/vo/request/RequestGetCommunityMemberListVo.java
@@ -1,0 +1,17 @@
+package com.example.community_service.community.vo.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestGetCommunityMemberListVo {
+
+    @NotNull
+    private String managerUuid;
+}

--- a/community/src/main/java/com/example/community_service/community/vo/request/RequestLeaveCommunityVo.java
+++ b/community/src/main/java/com/example/community_service/community/vo/request/RequestLeaveCommunityVo.java
@@ -1,0 +1,17 @@
+package com.example.community_service.community.vo.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestLeaveCommunityVo {
+
+    @NotNull
+    private String userUuid;
+}

--- a/community/src/main/java/com/example/community_service/community/vo/request/RequestRegisterManagerVo.java
+++ b/community/src/main/java/com/example/community_service/community/vo/request/RequestRegisterManagerVo.java
@@ -1,0 +1,20 @@
+package com.example.community_service.community.vo.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestRegisterManagerVo {
+
+    @NotNull
+    private String creatorUuid;
+
+    @NotNull
+    private String targetUuid;
+}

--- a/community/src/main/java/com/example/community_service/community/vo/response/ResponseGetCommunityMemberListVo.java
+++ b/community/src/main/java/com/example/community_service/community/vo/response/ResponseGetCommunityMemberListVo.java
@@ -1,0 +1,16 @@
+package com.example.community_service.community.vo.response;
+
+import com.example.community_service.community.domain.CommunityMember;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class ResponseGetCommunityMemberListVo {
+
+    private List<CommunityMember> communityMemberList;
+}

--- a/community/src/main/java/com/example/community_service/community/vo/response/ResponseLeaveCommunityVo.java
+++ b/community/src/main/java/com/example/community_service/community/vo/response/ResponseLeaveCommunityVo.java
@@ -1,0 +1,14 @@
+package com.example.community_service.community.vo.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class ResponseLeaveCommunityVo {
+
+    private Long communityId;
+    private String userUuid;
+}

--- a/community/src/main/java/com/example/community_service/community/vo/response/ResponseRegisterManagerVo.java
+++ b/community/src/main/java/com/example/community_service/community/vo/response/ResponseRegisterManagerVo.java
@@ -1,0 +1,14 @@
+package com.example.community_service.community.vo.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class ResponseRegisterManagerVo {
+
+    private Long communityId;
+    private String managerUuid;
+}

--- a/community/src/main/resources/application.yaml
+++ b/community/src/main/resources/application.yaml
@@ -1,5 +1,5 @@
 server:
-  port: 8001
+  port: 0
   shutdown: graceful
 
 management:
@@ -19,7 +19,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
# 변경점 👍
커뮤니티 가입 멤버 불러오기, 커뮤니티 탈퇴, 매니저 등록 기능 추가했습니다.

# 리팩토링 🛠
ServiceImpl이랑 Service부분 메서드가 너무 중구난방으로 작성되어 있어서.. 기능별로 분류했습니다.
 
# 비고 ✏
1. 엔티티 별로 createdAt이랑 updatedAt이 빠져있어서 추후에 모두 추가할 예정입니다.(TODO로 주석 달아놨습니다.)
2. 커뮤니티 가입 멤버 리스트 조회 시, 유저의 profileImage랑 username도 받아와야하는데... 서버간 통신을 안하니 일단 user쪽에 uuid던져서 해당되는 username이랑 profileImage 받아오는 API 추가하고 프론트에서 해당 API 호출하는 식으로 해야할 것 같습니다.
3. 서버 통신은 안해봤습니다ㅠ 일단 로컬로만 테스트 했고 내일 서버 통신 진행해보겠습니다.