### PR TITLE
FEAT delete manager, get manager list features

### DIFF
--- a/community/src/main/java/com/example/community_service/community/application/CommunityService.java
+++ b/community/src/main/java/com/example/community_service/community/application/CommunityService.java
@@ -22,4 +22,6 @@ public interface CommunityService {
 
     // 커뮤니티 매니저 관리
     ResponseRegisterManagerDto registerManager(RequestRegisterManagerDto requestDto, Long communityId);
+    ResponseDeleteManagerDto deleteManager(RequestDeleteManagerDto requestDto, Long communityId);
+    ResponseGetManagerListDto getManagerList(RequestGetManagerListDto requestDto, Long communityId);
 }

--- a/community/src/main/java/com/example/community_service/community/dto/request/RequestDeleteManagerDto.java
+++ b/community/src/main/java/com/example/community_service/community/dto/request/RequestDeleteManagerDto.java
@@ -1,0 +1,16 @@
+package com.example.community_service.community.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestDeleteManagerDto {
+
+    private String creatorUuid;
+    private String targetUuid;
+}

--- a/community/src/main/java/com/example/community_service/community/dto/request/RequestGetManagerListDto.java
+++ b/community/src/main/java/com/example/community_service/community/dto/request/RequestGetManagerListDto.java
@@ -1,0 +1,15 @@
+package com.example.community_service.community.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestGetManagerListDto {
+
+    private String creatorUuid;
+}

--- a/community/src/main/java/com/example/community_service/community/dto/response/ResponseDeleteManagerDto.java
+++ b/community/src/main/java/com/example/community_service/community/dto/response/ResponseDeleteManagerDto.java
@@ -1,0 +1,16 @@
+package com.example.community_service.community.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseDeleteManagerDto {
+
+    private String managerUuid;
+    private Long communityId;
+}

--- a/community/src/main/java/com/example/community_service/community/dto/response/ResponseGetManagerListDto.java
+++ b/community/src/main/java/com/example/community_service/community/dto/response/ResponseGetManagerListDto.java
@@ -1,0 +1,18 @@
+package com.example.community_service.community.dto.response;
+
+import com.example.community_service.community.domain.CommunityManager;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseGetManagerListDto {
+
+    List<CommunityManager> managerList;
+}

--- a/community/src/main/java/com/example/community_service/community/infrastructure/CommunityManagerRepository.java
+++ b/community/src/main/java/com/example/community_service/community/infrastructure/CommunityManagerRepository.java
@@ -3,10 +3,12 @@ package com.example.community_service.community.infrastructure;
 import com.example.community_service.community.domain.CommunityManager;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CommunityManagerRepository extends JpaRepository<CommunityManager, Long> {
 
     Boolean existsByCommunityIdAndManagerUuid(Long communityId, String managerUuid);
     Optional<CommunityManager> findByCommunityIdAndManagerUuid(Long communityId, String managerUuid);
+    List<CommunityManager> findAllByCommunityId(Long communityId);
 }

--- a/community/src/main/java/com/example/community_service/community/presentation/CommunityController.java
+++ b/community/src/main/java/com/example/community_service/community/presentation/CommunityController.java
@@ -22,7 +22,9 @@ public class CommunityController {
 
     private final CommunityServiceImpl communityService;
 
-    // todo: 모든 엔티티에 createdAt, updatedAt 추가하기
+    //todo: 모든 엔티티에 createdAt, updatedAt 추가하기 / 밴 해제 로직 다시 짜기
+    // 밴 해제 유저의 밴 데이터를 삭제하는 것이 아니라 밴 데이터의 밴 종료일을 현재 시간으로 업데이트하는 것으로 변경해야함.
+    // 만약 현재 시간이 밴 종료일보다 더 빠르다면 게시물 작성 등 기본적인 커뮤니티 활동을 할 수 없도록 해야함.
     @Tag(name = "커뮤니티 가입/탈퇴/조회") @Operation(summary = "커뮤니티 가입")
     @PostMapping("/{communityId}/users/me")
     public ApiResponse<Object> joinCommunity(
@@ -147,6 +149,7 @@ public class CommunityController {
         return ApiResponse.ofSuccess(responseVo);
     }
 
+    // todo: 수정해야함
     @Tag(name = "커뮤니티 밴 유저 관리") @Operation(summary = "커뮤니티 유저 밴 해제")
     @DeleteMapping("/{communityId}/ban-users")
     public ApiResponse<Object> unbanUser(
@@ -206,13 +209,39 @@ public class CommunityController {
 
     @Tag(name = "커뮤니티 매니저 관리") @Operation(summary = "커뮤니티 매니저 삭제")
     @DeleteMapping("/{communityId}/managers")
-    public ApiResponse<Object> deleteManager() {
-        return ApiResponse.ofSuccess();
+    public ApiResponse<Object> deleteManager(
+            @Valid @RequestBody RequestDeleteManagerVo requestVo, @PathVariable Long communityId) {
+
+        RequestDeleteManagerDto requestDto = RequestDeleteManagerDto.builder()
+                .creatorUuid(requestVo.getCreatorUuid())
+                .targetUuid(requestVo.getTargetUuid())
+                .build();
+
+        ResponseDeleteManagerDto responseDto = communityService.deleteManager(requestDto, communityId);
+
+        ResponseDeleteManagerVo responseVo = ResponseDeleteManagerVo.builder()
+                .managerUuid(responseDto.getManagerUuid())
+                .communityId(responseDto.getCommunityId())
+                .build();
+
+        return ApiResponse.ofSuccess(responseVo);
     }
 
     @Tag(name = "커뮤니티 매니저 관리") @Operation(summary = "커뮤니티 매니저 목록 조회")
     @PostMapping("/{communityId}/managers/list")
-    public ApiResponse<Object> getManagerList() {
-        return ApiResponse.ofSuccess();
+    public ApiResponse<Object> getManagerList(
+            @Valid @RequestBody RequestGetManagerListVo requestVo, @PathVariable Long communityId) {
+
+        RequestGetManagerListDto requestDto = RequestGetManagerListDto.builder()
+                .creatorUuid(requestVo.getCreatorUuid())
+                .build();
+
+        ResponseGetManagerListDto responseDto = communityService.getManagerList(requestDto, communityId);
+
+        ResponseGetManagerListVo responseVo = ResponseGetManagerListVo.builder()
+                .managerList(responseDto.getManagerList())
+                .build();
+
+        return ApiResponse.ofSuccess(responseVo);
     }
 }

--- a/community/src/main/java/com/example/community_service/community/vo/request/RequestDeleteManagerVo.java
+++ b/community/src/main/java/com/example/community_service/community/vo/request/RequestDeleteManagerVo.java
@@ -1,0 +1,16 @@
+package com.example.community_service.community.vo.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestDeleteManagerVo {
+
+    private String creatorUuid;
+    private String targetUuid;
+}

--- a/community/src/main/java/com/example/community_service/community/vo/request/RequestGetManagerListVo.java
+++ b/community/src/main/java/com/example/community_service/community/vo/request/RequestGetManagerListVo.java
@@ -1,0 +1,15 @@
+package com.example.community_service.community.vo.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RequestGetManagerListVo {
+
+    private String creatorUuid;
+}

--- a/community/src/main/java/com/example/community_service/community/vo/response/ResponseDeleteManagerVo.java
+++ b/community/src/main/java/com/example/community_service/community/vo/response/ResponseDeleteManagerVo.java
@@ -1,0 +1,14 @@
+package com.example.community_service.community.vo.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class ResponseDeleteManagerVo {
+
+    private String managerUuid;
+    private Long communityId;
+}

--- a/community/src/main/java/com/example/community_service/community/vo/response/ResponseGetManagerListVo.java
+++ b/community/src/main/java/com/example/community_service/community/vo/response/ResponseGetManagerListVo.java
@@ -1,0 +1,16 @@
+package com.example.community_service.community.vo.response;
+
+import com.example.community_service.community.domain.CommunityManager;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class ResponseGetManagerListVo {
+
+    private List<CommunityManager> managerList;
+}


### PR DESCRIPTION
# 변경점 👍
매니저 권한 삭제, 커뮤니티의 매니저 전체 조회 기능 추가됐습니다.
 
# 리팩토링 🛠
매니저 등록 시에 밴 된 유저는 등록이 불가능해야하는데 등록이 가능해서 불가능하도록 수정했습니다.

# 비고 ✏
기존의 유저 밴 해제 시 밴 데이터를 아예 삭제하는 로직이었는데, 해당 로직으로 사용하게 되면 1분, 1초마다 스케줄러를 돌려서 해당 유저의 밴 종료일과 현재 시간을 비교해야 합니다. 서비스에 상당한 부하가 가기 때문에 밴 데이터를 삭제하지 않고 게시글 작성이나 커뮤니티 활동을 할 때 밴 데이터를 가지고 활동을 허용할지 말지 검증하는 작업을 진행할 것 같습니다. 생각해보니 수정 사항이 많아졌네요.. 매니저 등록 시에 밴 유저 확인 로직도 재작성을 해야 할 것 같습니다ㅠ
